### PR TITLE
Add static EmeraldCon website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Emeraldcon
+# EmeraldCon Website
+
+This repository contains the source for the unofficial EmeraldCon 2025 afterparty website. Open `index.html` in your browser to view the page.
+
+## Development
+
+The site is completely static: HTML and CSS only. Feel free to modify `style.css` or `index.html` to tweak the content or appearance.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EmeraldCon 2025</title>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>EmeraldCon 2025</h1>
+    <h2>The Unofficial HOPE Afterparty</h2>
+  </header>
+  <main>
+    <section id="dates" class="card">
+      <h3>Event Dates</h3>
+      <p>August 15&ndash;17, 2025<br><em>Coincides with HOPE_16 at St. John's University, Queens, NY</em></p>
+    </section>
+    <section id="venue" class="card">
+      <h3>Venue</h3>
+      <p><strong>The Emerald</strong><br>A classic dive bar located adjacent to the conference hotel. Known for its authentic Irish pub atmosphere, it's the unofficial gathering spot for HOPE attendees seeking a more intimate and relaxed setting.</p>
+    </section>
+    <section id="who" class="card">
+      <h3>Who Should Attend</h3>
+      <ul>
+        <li><strong>Hackers &amp; Tinkerers</strong>: Whether you're into hardware hacking, software exploits, or just love the culture, you'll find like-minded individuals here.</li>
+        <li><strong>Security Professionals</strong>: From pentesters to red teamers, it's a great place to unwind and share war stories.</li>
+        <li><strong>Tech Enthusiasts</strong>: If you're passionate about technology and its societal impacts, this is your crowd.</li>
+        <li><strong>Creatives &amp; Artists</strong>: The intersection of technology and art is a frequent topic of discussion.</li>
+        <li><strong>Anyone Who Loves a Good Pint</strong>: If you're looking for a place to relax, network, and enjoy a drink, The Emerald is the spot.</li>
+      </ul>
+    </section>
+    <section id="activities" class="card">
+      <h3>Activities</h3>
+      <ul>
+        <li>Informal Talks: impromptu discussions on topics ranging from cybersecurity to open-source projects.</li>
+        <li>Live Demos: show off your latest project or learn about others' work in a casual setting.</li>
+        <li>Networking: meet new people, exchange ideas, and build connections that could lead to future collaborations.</li>
+        <li>Games &amp; Challenges: participate in friendly competitions, from lockpicking contests to trivia nights.</li>
+      </ul>
+    </section>
+    <section id="getting-there" class="card">
+      <h3>Getting There</h3>
+      <p>The Emerald is conveniently located near the conference hotel. It's within walking distance, making it easy to pop in between sessions or after a long day at the conference.</p>
+    </section>
+    <section id="participate" class="card">
+      <h3>How to Participate</h3>
+      <ul>
+        <li>Show Up: no registration required. Just walk in and join the fun.</li>
+        <li>Spread the Word: share this information with fellow attendees and encourage them to join.</li>
+        <li>Contribute: if you have something to share&mdash;whether it's a project, topic for discussion, or just a good story&mdash;feel free to contribute.</li>
+      </ul>
+    </section>
+    <section id="why" class="card">
+      <h3>Why Attend EmeraldCon?</h3>
+      <p>While HOPE_16 offers a wealth of structured content, EmeraldCon provides a space for organic interactions and relaxed conversations. It's where the community comes together in a more personal setting, away from the formalities of the main conference.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 EmeraldCon. This is an unofficial event.</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,97 @@
+body {
+  margin: 0;
+  font-family: 'Fira Code', monospace;
+  background: #0d0d0d;
+  color: #e0e0e0;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.hero {
+  background: radial-gradient(circle at top, #102030, #000);
+  text-align: center;
+  padding: 4rem 1rem;
+  color: #0ff;
+}
+
+.hero h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 3rem;
+  margin: 0;
+  text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
+}
+
+.hero h2 {
+  font-size: 1.5rem;
+  color: #0f0;
+  text-shadow: 0 0 5px #0f0;
+}
+
+main {
+  flex: 1;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.card {
+  background: #111;
+  border: 1px solid #222;
+  box-shadow: 0 0 10px rgba(0,255,255,0.2);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border-radius: 8px;
+}
+
+.card h3 {
+  font-family: 'Orbitron', sans-serif;
+  color: #0ff;
+  margin-top: 0;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #000;
+  color: #555;
+  font-size: 0.8rem;
+}
+
+ul {
+  padding-left: 1.2rem;
+}
+
+li::marker {
+  color: #0ff;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background: #fafafa;
+    color: #222;
+  }
+  .hero {
+    background: linear-gradient(135deg, #b2dfdb, #80cbc4);
+    color: #004d40;
+  }
+  .hero h1 {
+    text-shadow: none;
+  }
+  .hero h2 {
+    color: #00695c;
+  }
+  .card {
+    background: #fff;
+    border-color: #ddd;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+  .card h3 {
+    color: #00695c;
+  }
+  footer {
+    background: #e0f2f1;
+    color: #004d40;
+  }
+}


### PR DESCRIPTION
## Summary
- build index page for EmeraldCon 2025
- add custom styling
- document how to view the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba9c369448328ae0d2f255cbdff5c