### PR TITLE
Add V for Vendetta themed styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EmeraldCon 2025</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Orbitron:wght@400;700&family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header class="hero">
     <h1>EmeraldCon 2025</h1>
     <h2>The Unofficial HOPE Afterparty</h2>
+    <p class="tagline">Remember, remember the 5th of November</p>
   </header>
   <main>
     <section id="dates" class="card">
@@ -55,6 +56,10 @@
     <section id="why" class="card">
       <h3>Why Attend EmeraldCon?</h3>
       <p>While HOPE_16 offers a wealth of structured content, EmeraldCon provides a space for organic interactions and relaxed conversations. It's where the community comes together in a more personal setting, away from the formalities of the main conference.</p>
+    </section>
+    <section id="vendetta" class="card v-theme">
+      <h3>V for Vendetta Mood</h3>
+      <p>A dystopian Britain under a surveillance-state government that manipulates fear to keep people in line. Authoritarian regimes use legal pretexts, propaganda, and violent "spectacles" to quash dissent—echoing the coercive games that pit civilians against one another.</p>
     </section>
   </main>
   <footer>

--- a/style.css
+++ b/style.css
@@ -9,24 +9,32 @@ body {
   min-height: 100vh;
 }
 
+
 .hero {
-  background: radial-gradient(circle at top, #102030, #000);
+  background: radial-gradient(circle at top, #300, #000);
   text-align: center;
   padding: 4rem 1rem;
-  color: #0ff;
+  color: #ff4d4d;
 }
 
+
 .hero h1 {
-  font-family: 'Orbitron', sans-serif;
+  font-family: 'Cinzel', serif;
   font-size: 3rem;
   margin: 0;
-  text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
+  text-shadow: 0 0 10px #ff4d4d, 0 0 20px #ff4d4d;
 }
 
 .hero h2 {
   font-size: 1.5rem;
-  color: #0f0;
-  text-shadow: 0 0 5px #0f0;
+  color: #eee;
+  text-shadow: 0 0 5px #ff4d4d;
+}
+.tagline {
+  font-family: 'Cinzel', serif;
+  color: #ff4d4d;
+  margin-top: 0.5rem;
+  font-style: italic;
 }
 
 main {
@@ -51,6 +59,16 @@ main {
   margin-top: 0;
 }
 
+.v-theme {
+  background: linear-gradient(135deg, rgba(92, 0, 0, 0.8), rgba(0, 0, 0, 0.9));
+  border-color: #5c0000;
+  box-shadow: 0 0 10px rgba(255, 77, 77, 0.2);
+}
+
+.v-theme h3 {
+  color: #ff4d4d;
+}
+
 footer {
   text-align: center;
   padding: 1rem;
@@ -73,14 +91,18 @@ li::marker {
     color: #222;
   }
   .hero {
-    background: linear-gradient(135deg, #b2dfdb, #80cbc4);
-    color: #004d40;
+    background: linear-gradient(135deg, #ffebee, #ffcdd2);
+    color: #b71c1c;
   }
   .hero h1 {
     text-shadow: none;
+    font-family: 'Cinzel', serif;
   }
   .hero h2 {
-    color: #00695c;
+    color: #b71c1c;
+  }
+  .tagline {
+    color: #b71c1c;
   }
   .card {
     background: #fff;


### PR DESCRIPTION
## Summary
- use Cinzel font and dark red color scheme inspired by *V for Vendetta*
- add a banner tagline referencing November 5th
- include a themed section describing the dystopian mood

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bab9f77b08328bb5733206b0e96fd