### PR TITLE
Add placeholder schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,20 @@
         <li>Games &amp; Challenges: participate in friendly competitions, from lockpicking contests to trivia nights.</li>
       </ul>
     </section>
+    <section id="schedule" class="card">
+      <h3>Schedule</h3>
+      <table class="schedule-table">
+        <thead>
+          <tr><th>Date</th><th>Planned Events</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>August 15</td><td>Kickoff meetup and welcome drinks</td></tr>
+          <tr><td>August 16</td><td>Casual talks, live demos, and challenges</td></tr>
+          <tr><td>August 17</td><td>Farewell brunch and wrap up</td></tr>
+        </tbody>
+      </table>
+      <p class="reviews">Subject to change &mdash; final schedule coming soon.</p>
+    </section>
     <section id="getting-there" class="card">
       <h3>Getting There</h3>
       <p>The Emerald is conveniently located near the conference hotel. It's within walking distance, making it easy to pop in between sessions or after a long day at the conference.</p>

--- a/style.css
+++ b/style.css
@@ -175,6 +175,22 @@ li::marker {
   color: #aaa;
 }
 
+.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+.schedule-table th,
+.schedule-table td {
+  border: 1px solid var(--card-border);
+  padding: 0.5rem;
+  text-align: left;
+}
+.schedule-table th {
+  background: var(--accent-color);
+  color: #fff;
+}
+
 
 @media (prefers-color-scheme: light) {
   body {
@@ -205,5 +221,12 @@ li::marker {
   footer {
     background: #e0f2f1;
     color: #004d40;
+  }
+  .schedule-table th {
+    background: #00695c;
+  }
+  .schedule-table th,
+  .schedule-table td {
+    border-color: #ddd;
   }
 }


### PR DESCRIPTION
## Summary
- add Schedule section with a simple table outlining activities per day
- style schedule table

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_686bca25323483288406e1528c95bc8f